### PR TITLE
Perl 6: Add more native types. (num32, num64, long, longlong, Pointer, size_t and str)

### DIFF
--- a/syntax/perl6.vim
+++ b/syntax/perl6.vim
@@ -101,7 +101,8 @@ let s:keywords = {
  \   "rat rat1 rat2 rat4 rat8 rat16 rat32 rat64",
  \   "buf buf1 buf2 buf4 buf8 buf16 buf32 buf64",
  \   "uint uint1 uint2 uint4 uint8 uint16 uint32 bit bool",
- \   "uint64 utf8 utf16 utf32 bag set mix num complex",
+ \   "uint64 utf8 utf16 utf32 bag set mix complex",
+ \   "num num32 num64 long longlong Pointer size_t str",
  \ ],
 \ }
 


### PR DESCRIPTION
All types I added are listed here: https://docs.perl6.org/language/nativecall#Passing_and_Returning_Values except for str which you can see here in roast: https://github.com/perl6/roast/blob/master/S02-types/native.t#L43

(They are all in the design docs too, but I wanted to link the most up to date info available)