### PR TITLE
Update homepage and issue tracker urls

### DIFF
--- a/ftplugin/perl6.vim
+++ b/ftplugin/perl6.vim
@@ -1,8 +1,8 @@
 " Vim filetype plugin file
 " Language:      Perl 6
 " Maintainer:    vim-perl <vim-perl@googlegroups.com>
-" Homepage:      http://github.com/vim-perl/vim-perl
-" Bugs/requests: http://github.com/vim-perl/vim-perl/issues
+" Homepage:      https://github.com/vim-perl/vim-perl6
+" Bugs/requests: https://github.com/vim-perl/vim-perl6/issues
 " Last Change:   {{LAST_CHANGE}}
 " Contributors:  Hinrik Örn Sigurðsson <hinrik.sig@gmail.com>
 "

--- a/indent/perl6.vim
+++ b/indent/perl6.vim
@@ -1,8 +1,8 @@
 " Vim indent file
 " Language:      Perl 6
 " Maintainer:    vim-perl <vim-perl@googlegroups.com>
-" Homepage:      http://github.com/vim-perl/vim-perl
-" Bugs/requests: http://github.com/vim-perl/vim-perl/issues
+" Homepage:      https://github.com/vim-perl/vim-perl6
+" Bugs/requests: https://github.com/vim-perl/vim-perl6/issues
 " Last Change:   {{LAST_CHANGE}}
 " Contributors:  Andy Lester <andy@petdance.com>
 "                Hinrik Örn Sigurðsson <hinrik.sig@gmail.com>

--- a/syntax/perl6.vim
+++ b/syntax/perl6.vim
@@ -1,8 +1,8 @@
 " Vim syntax file
 " Language:      Perl 6
 " Maintainer:    vim-perl <vim-perl@googlegroups.com>
-" Homepage:      http://github.com/vim-perl/vim-perl/tree/master
-" Bugs/requests: http://github.com/vim-perl/vim-perl/issues
+" Homepage:      https://github.com/vim-perl/vim-perl6
+" Bugs/requests: https://github.com/vim-perl/vim-perl6/issues
 " Last Change:   {{LAST_CHANGE}}
 
 " Contributors:  Luke Palmer <fibonaci@babylonia.flatirons.org>

--- a/syntax/perl6.vim.pre
+++ b/syntax/perl6.vim.pre
@@ -1,8 +1,8 @@
 " Vim syntax file
 " Language:      Perl 6
 " Maintainer:    vim-perl <vim-perl@googlegroups.com>
-" Homepage:      http://github.com/vim-perl/vim-perl/tree/master
-" Bugs/requests: http://github.com/vim-perl/vim-perl/issues
+" Homepage:      https://github.com/vim-perl/vim-perl6
+" Bugs/requests: https://github.com/vim-perl/vim-perl6/issues
 " Last Change:   {{LAST_CHANGE}}
 
 " Contributors:  Luke Palmer <fibonaci@babylonia.flatirons.org>


### PR DESCRIPTION
Since these files are maintained at https://github.com/vim-perl/vim-perl6, these urls should be fixed not to make contributors confusing.