### PR TITLE
Remove - and +, as these will almost always result in faulty code

### DIFF
--- a/ftplugin/perl6.vim
+++ b/ftplugin/perl6.vim
@@ -114,8 +114,6 @@ if get(g:, 'perl6_unicode_abbrevs', 0)
     iabbrev <buffer> **7 ⁷
     iabbrev <buffer> **8 ⁸
     iabbrev <buffer> **9 ⁹
-    iabbrev <buffer> + ⁺
-    iabbrev <buffer> - −
     iabbrev <buffer> ... …
     iabbrev <buffer> / ÷
     iabbrev <buffer> << «


### PR DESCRIPTION
These versions of the + and - aren't meant for being a prettier version of the standard + and -. In fact, it'll break math that requires the standard + and -. It appears these are meant for use in contexts such as `x⁷−⁸`.